### PR TITLE
fix(聊天未读消息数量): 聊天自己发送的语音，不应该记成未读消息。

### DIFF
--- a/standard/component/DetailListView.tsx
+++ b/standard/component/DetailListView.tsx
@@ -189,8 +189,7 @@ export default class extends React.PureComponent {
                 && cur.from
                 && me == cur.from
                 && cur.data
-                && cur.data.isSystem
-                && cur.data.isSystem != true) {
+                && (!(cur.data.isSystem && cur.data.isSystem == true))) {
                 hasFromMe = true;
             }
             if (cur.data.isSystem && cur.data.isSystem == true) {


### PR DESCRIPTION
--bug=1017707 --user=田学军 【手机端】【沟通】浏览会话历史消息时，发送语音，显示”X条新消息“
https://www.tapd.cn/23787791/s/1079334